### PR TITLE
parsing dom error fixed.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "commander": "1.1.1",
     "async": "0.1.22",
-    "jsdom": "~0.5.6",
+    "jsdom": "3.1.2",
     "handlebars": "~1.0.12",
     "glob": "~3.2.8"
   },


### PR DESCRIPTION
when user use jsdom ~0.5.6, the error occurs below.

can-compile/node_modules/jsdom/lib/jsdom/level1/core.js:432
  set nodeName() { throw new core.DOMException();},

----
Using jsdom 3.1.2 is fine.

http://stackoverflow.com/questions/28756230/nodejs-parsing-dom-error-with-strict-mode